### PR TITLE
Update dependencies and workflows for Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [8.5, 8.4, 8.3]
         laravel: [13.*, 12.*, 11.*, 10.*]
-        stability: [prefer-stable]
+        stability: [prefer-stable, prefer-lowest]
         include:
           - laravel: 13.*
             testbench: 11.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,10 +21,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: [12.*, 11.*, 10.*]
-        stability: [prefer-lowest, prefer-stable]
+        php: [8.5, 8.4, 8.3]
+        laravel: [13.*, 12.*, 11.*, 10.*]
+        stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,6 +33,9 @@ jobs:
             testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
+        exclude:
+          - php: 8.5
+            laravel: 10.*
 
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/routing": "^10.0|^11.0|^12.0",
-        "illuminate/http": "^10.0|^11.0|^12.0"
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/http": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^2.34|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.4|^3.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.34|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.4|^3.0|^4.0",
         "mockery/mockery": "^1.6",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/http": "^10.0|^11.0|^12.0|^13.0"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -97,50 +97,14 @@ parameters:
 			path: src/Http/Responses/ProblemDetailsResponse.php
 
 		-
-			message: '#^Parameter \#3 \$callback of static method Illuminate\\Support\\Facades\\Cache\:\:remember\(\) expects Closure, callable\(\)\: mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Services/AttributeCacheService.php
-
-		-
 			message: '#^Method ShahGhasiAdil\\LaravelApiVersioning\\Services\\AttributeVersionResolver\:\:createVersionInfo\(\) has parameter \$class with generic class ReflectionClass but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/Services/AttributeVersionResolver.php
 
 		-
-			message: '#^Method ShahGhasiAdil\\LaravelApiVersioning\\Services\\AttributeVersionResolver\:\:getAllVersionsForRoute\(\) should return array\<string\> but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Services/AttributeVersionResolver.php
-
-		-
 			message: '#^Method ShahGhasiAdil\\LaravelApiVersioning\\Services\\AttributeVersionResolver\:\:getDeprecationInfo\(\) has parameter \$reflection with generic class ReflectionClass but does not specify its types\: T$#'
 			identifier: missingType.generics
-			count: 1
-			path: src/Services/AttributeVersionResolver.php
-
-		-
-			message: '#^Method ShahGhasiAdil\\LaravelApiVersioning\\Services\\AttributeVersionResolver\:\:getVersionsFromAttributes\(\) has parameter \$reflection with generic class ReflectionClass but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Services/AttributeVersionResolver.php
-
-		-
-			message: '#^Method ShahGhasiAdil\\LaravelApiVersioning\\Services\\AttributeVersionResolver\:\:getVersionsFromAttributes\(\) should return array\<string\> but returns array\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Services/AttributeVersionResolver.php
-
-		-
-			message: '#^Method ShahGhasiAdil\\LaravelApiVersioning\\Services\\AttributeVersionResolver\:\:hasAttribute\(\) has parameter \$reflection with generic class ReflectionClass but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Services/AttributeVersionResolver.php
-
-		-
-			message: '#^Method ShahGhasiAdil\\LaravelApiVersioning\\Services\\AttributeVersionResolver\:\:resolveVersionForRoute\(\) should return ShahGhasiAdil\\LaravelApiVersioning\\ValueObjects\\VersionInfo\|null but returns mixed\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Services/AttributeVersionResolver.php
 
@@ -166,12 +130,6 @@ parameters:
 			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Services/AttributeVersionResolver.php
-
-		-
-			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/Services/AttributeVersionResolver.php
 
 		-

--- a/src/ApiVersioningServiceProvider.php
+++ b/src/ApiVersioningServiceProvider.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace ShahGhasiAdil\LaravelApiVersioning;
 
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use ShahGhasiAdil\LaravelApiVersioning\Console\Commands\ApiCacheClearCommand;
 use ShahGhasiAdil\LaravelApiVersioning\Console\Commands\ApiVersionConfigCommand;
@@ -26,8 +29,8 @@ class ApiVersioningServiceProvider extends ServiceProvider
             'api-versioning'
         );
 
-        $this->app->singleton(VersionManager::class, function (\Illuminate\Contracts\Foundation\Application $app): VersionManager {
-            /** @var \Illuminate\Config\Repository $configRepo */
+        $this->app->singleton(VersionManager::class, function (Application $app): VersionManager {
+            /** @var Repository $configRepo */
             $configRepo = $app->make('config');
             /** @var array<string, mixed> $config */
             $config = $configRepo->get('api-versioning', []);
@@ -35,8 +38,8 @@ class ApiVersioningServiceProvider extends ServiceProvider
             return new VersionManager($config);
         });
 
-        $this->app->singleton(AttributeCacheService::class, function (\Illuminate\Contracts\Foundation\Application $app): AttributeCacheService {
-            /** @var \Illuminate\Config\Repository $configRepo */
+        $this->app->singleton(AttributeCacheService::class, function (Application $app): AttributeCacheService {
+            /** @var Repository $configRepo */
             $configRepo = $app->make('config');
             /** @var array{enabled?: bool|string, ttl?: int|string} $config */
             $config = $configRepo->get('api-versioning.cache', []);
@@ -47,18 +50,18 @@ class ApiVersioningServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->singleton(AttributeVersionResolver::class, function (\Illuminate\Contracts\Foundation\Application $app): AttributeVersionResolver {
+        $this->app->singleton(AttributeVersionResolver::class, function (Application $app): AttributeVersionResolver {
             return new AttributeVersionResolver(
                 $app->make(VersionManager::class),
                 $app->make(AttributeCacheService::class)
             );
         });
 
-        $this->app->singleton(VersionConfigService::class, function (\Illuminate\Contracts\Foundation\Application $app): VersionConfigService {
+        $this->app->singleton(VersionConfigService::class, function (Application $app): VersionConfigService {
             return new VersionConfigService;
         });
 
-        $this->app->singleton(VersionComparator::class, function (\Illuminate\Contracts\Foundation\Application $app): VersionComparator {
+        $this->app->singleton(VersionComparator::class, function (Application $app): VersionComparator {
             return new VersionComparator;
         });
     }
@@ -69,7 +72,7 @@ class ApiVersioningServiceProvider extends ServiceProvider
             __DIR__.'/../config/api-versioning.php' => config_path('api-versioning.php'),
         ], 'config');
 
-        /** @var \Illuminate\Routing\Router $router */
+        /** @var Router $router */
         $router = $this->app->make('router');
         $router->aliasMiddleware('api.version', AttributeApiVersionMiddleware::class);
 

--- a/src/Console/Commands/ApiVersionHealthCommand.php
+++ b/src/Console/Commands/ApiVersionHealthCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ShahGhasiAdil\LaravelApiVersioning\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use ShahGhasiAdil\LaravelApiVersioning\Services\AttributeVersionResolver;
 use ShahGhasiAdil\LaravelApiVersioning\Services\VersionManager;
@@ -61,10 +62,10 @@ class ApiVersionHealthCommand extends Command
 
         // Check 4: Routes with version attributes
         $allRoutes = $this->router->getRoutes();
-        /** @var \Illuminate\Routing\Route[] $routeArray */
+        /** @var Route[] $routeArray */
         $routeArray = iterator_to_array($allRoutes, false);
         $routes = collect($routeArray);
-        $versionedRoutes = $routes->filter(function (\Illuminate\Routing\Route $route): bool {
+        $versionedRoutes = $routes->filter(function (Route $route): bool {
             $versions = $this->resolver->getAllVersionsForRoute($route);
 
             return $versions !== [];

--- a/src/Console/Commands/ApiVersionsCommand.php
+++ b/src/Console/Commands/ApiVersionsCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ShahGhasiAdil\LaravelApiVersioning\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use ShahGhasiAdil\LaravelApiVersioning\Services\AttributeVersionResolver;
 use ShahGhasiAdil\LaravelApiVersioning\Services\VersionManager;
@@ -31,17 +32,17 @@ class ApiVersionsCommand extends Command
     public function handle(): int
     {
         $allRoutes = $this->router->getRoutes();
-        /** @var \Illuminate\Routing\Route[] $routeArray */
+        /** @var Route[] $routeArray */
         $routeArray = iterator_to_array($allRoutes, false);
 
-        $routes = collect($routeArray)->filter(function (\Illuminate\Routing\Route $route): bool {
+        $routes = collect($routeArray)->filter(function (Route $route): bool {
             return str_contains($route->uri(), 'api/');
         });
 
         /** @var string|null $routeFilter */
         $routeFilter = $this->option('route');
         if (is_string($routeFilter) && $routeFilter !== '') {
-            $routes = $routes->filter(fn (\Illuminate\Routing\Route $route): bool => str_contains($route->uri(), $routeFilter));
+            $routes = $routes->filter(fn (Route $route): bool => str_contains($route->uri(), $routeFilter));
         }
 
         $headers = ['Method', 'URI', 'Controller', 'Versions', 'Deprecated', 'Sunset Date'];

--- a/src/Examples/DynamicUserResource.php
+++ b/src/Examples/DynamicUserResource.php
@@ -3,14 +3,15 @@
 namespace ShahGhasiAdil\LaravelApiVersioning\Examples;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use ShahGhasiAdil\LaravelApiVersioning\Http\Resources\VersionedJsonResource;
 
 /**
  * @property int $id
  * @property string $name
  * @property string $email
- * @property \Illuminate\Support\Carbon $created_at
- * @property \Illuminate\Support\Carbon $updated_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property string|null $avatar_url
  * @property string|null $bio
  * @property string|null $theme

--- a/src/Examples/UserResource.php
+++ b/src/Examples/UserResource.php
@@ -3,15 +3,16 @@
 namespace ShahGhasiAdil\LaravelApiVersioning\Examples;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use ShahGhasiAdil\LaravelApiVersioning\Http\Resources\VersionedJsonResource;
 
 /**
  * @property int $id
  * @property string $name
  * @property string $email
- * @property \Illuminate\Support\Carbon $created_at
- * @property \Illuminate\Support\Carbon $updated_at
- * @property \Illuminate\Support\Carbon|null $last_login
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Carbon|null $last_login
  * @property string|null $avatar_url
  * @property string|null $bio
  * @property string|null $theme

--- a/src/Middleware/AttributeApiVersionMiddleware.php
+++ b/src/Middleware/AttributeApiVersionMiddleware.php
@@ -22,7 +22,7 @@ class AttributeApiVersionMiddleware
     ) {}
 
     /**
-     * @param  \Closure(\Illuminate\Http\Request): Response  $next
+     * @param  Closure(Request): Response  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/src/Services/AttributeCacheService.php
+++ b/src/Services/AttributeCacheService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShahGhasiAdil\LaravelApiVersioning\Services;
 
+use Closure;
 use Illuminate\Cache\TaggableStore;
 use Illuminate\Support\Facades\Cache;
 
@@ -27,9 +28,9 @@ class AttributeCacheService
      * `api_versioning` tag, enabling a precise flush via {@see flush()}.
      *
      * @param  string  $key  Cache key (without prefix)
-     * @param  callable  $callback  Callback to generate value if not cached
+     * @param  Closure(): mixed  $callback  Callback to generate value if not cached
      */
-    public function remember(string $key, callable $callback): mixed
+    public function remember(string $key, Closure $callback): mixed
     {
         if (! $this->enabled) {
             return $callback();

--- a/src/Services/AttributeVersionResolver.php
+++ b/src/Services/AttributeVersionResolver.php
@@ -186,7 +186,7 @@ class AttributeVersionResolver
      * Flatten a list of ReflectionAttribute instances (all implementing HasVersions)
      * into a unique, merged array of version strings.
      *
-     * @param  \ReflectionAttribute[]  $attributes
+     * @param  ReflectionAttribute[]  $attributes
      * @return string[]
      */
     private function flattenVersionAttributes(array $attributes): array

--- a/src/Services/AttributeVersionResolver.php
+++ b/src/Services/AttributeVersionResolver.php
@@ -45,6 +45,7 @@ class AttributeVersionResolver
 
         $cacheKey = $this->cache->generateRouteKey($controllerClass, $action, $requestedVersion);
 
+        /** @var VersionInfo|null $result */
         $result = $this->cache->remember($cacheKey, function () use ($controller, $action, $requestedVersion) {
             $reflectionClass = new ReflectionClass($controller);
             $reflectionMethod = $reflectionClass->getMethod($action);
@@ -113,7 +114,8 @@ class AttributeVersionResolver
         $controllerClass = get_class($controller);
         $cacheKey = $this->cache->generateRouteVersionsKey($controllerClass, $action);
 
-        return $this->cache->remember($cacheKey, function () use ($controller, $action) {
+        /** @var string[] $result */
+        $result = $this->cache->remember($cacheKey, function () use ($controller, $action) {
             $reflectionClass = new ReflectionClass($controller);
             $reflectionMethod = $reflectionClass->getMethod($action);
 
@@ -135,6 +137,8 @@ class AttributeVersionResolver
 
             return $this->flattenVersionAttributes($classVersionAttrs);
         });
+
+        return $result;
     }
 
     /**
@@ -145,6 +149,9 @@ class AttributeVersionResolver
         self::$memoryCache = [];
     }
 
+    /**
+     * @param  string[]|null  $routeVersions
+     */
     private function createVersionInfo(
         string $version,
         bool $isNeutral,
@@ -186,7 +193,7 @@ class AttributeVersionResolver
      * Flatten a list of ReflectionAttribute instances (all implementing HasVersions)
      * into a unique, merged array of version strings.
      *
-     * @param  \ReflectionAttribute[]  $attributes
+     * @param  list<ReflectionAttribute<HasVersions>>  $attributes
      * @return string[]
      */
     private function flattenVersionAttributes(array $attributes): array
@@ -195,9 +202,15 @@ class AttributeVersionResolver
             return [];
         }
 
-        return array_unique(array_merge(...array_map(
-            fn ($attr) => $attr->newInstance()->getVersions(),
+        /** @var list<string[]> $versionArrays */
+        $versionArrays = array_map(
+            static fn ($attr) => $attr->newInstance()->getVersions(),
             $attributes
-        )));
+        );
+
+        /** @var string[] $merged */
+        $merged = array_merge(...$versionArrays);
+
+        return array_values(array_unique($merged));
     }
 }

--- a/src/Testing/ApiVersionTestCase.php
+++ b/src/Testing/ApiVersionTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShahGhasiAdil\LaravelApiVersioning\Testing;
 
+use Illuminate\Http\Response;
 use Illuminate\Testing\TestResponse;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use ShahGhasiAdil\LaravelApiVersioning\ApiVersioningServiceProvider;
@@ -62,7 +63,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
      * Call the given URI with API version header
      *
      * @param  array<string, string>  $headers
-     * @return TestResponse<\Illuminate\Http\Response>
+     * @return TestResponse<Response>
      */
     protected function getWithVersion(string $uri, string $version, array $headers = []): TestResponse
     {
@@ -75,7 +76,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
      * Call the given URI with API version query parameter
      *
      * @param  array<string, string>  $headers
-     * @return TestResponse<\Illuminate\Http\Response>
+     * @return TestResponse<Response>
      */
     protected function getWithVersionQuery(string $uri, string $version, array $headers = []): TestResponse
     {
@@ -89,7 +90,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
      *
      * @param  array<string, mixed>  $data
      * @param  array<string, string>  $headers
-     * @return TestResponse<\Illuminate\Http\Response>
+     * @return TestResponse<Response>
      */
     protected function postWithVersion(string $uri, array $data, string $version, array $headers = []): TestResponse
     {
@@ -103,7 +104,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
      *
      * @param  array<string, mixed>  $data
      * @param  array<string, string>  $headers
-     * @return TestResponse<\Illuminate\Http\Response>
+     * @return TestResponse<Response>
      */
     protected function putWithVersion(string $uri, array $data, string $version, array $headers = []): TestResponse
     {
@@ -116,7 +117,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
      * Make a DELETE request with API version
      *
      * @param  array<string, string>  $headers
-     * @return TestResponse<\Illuminate\Http\Response>
+     * @return TestResponse<Response>
      */
     protected function deleteWithVersion(string $uri, string $version, array $headers = []): TestResponse
     {
@@ -128,7 +129,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
     /**
      * Assert response has correct version headers
      *
-     * @param  TestResponse<\Illuminate\Http\Response>  $response
+     * @param  TestResponse<Response>  $response
      */
     protected function assertApiVersion(TestResponse $response, string $expectedVersion): static
     {
@@ -140,7 +141,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
     /**
      * Assert response indicates deprecation
      *
-     * @param  TestResponse<\Illuminate\Http\Response>  $response
+     * @param  TestResponse<Response>  $response
      */
     protected function assertApiVersionDeprecated(TestResponse $response, ?string $sunsetDate = null): static
     {
@@ -156,7 +157,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
     /**
      * Assert response supports specific versions
      *
-     * @param  TestResponse<\Illuminate\Http\Response>  $response
+     * @param  TestResponse<Response>  $response
      * @param  string[]  $versions
      */
     protected function assertSupportedVersions(TestResponse $response, array $versions): static
@@ -169,7 +170,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
     /**
      * Assert response indicates version is not deprecated
      *
-     * @param  TestResponse<\Illuminate\Http\Response>  $response
+     * @param  TestResponse<Response>  $response
      */
     protected function assertApiVersionNotDeprecated(TestResponse $response): static
     {
@@ -181,7 +182,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
     /**
      * Assert response has route-specific version headers
      *
-     * @param  TestResponse<\Illuminate\Http\Response>  $response
+     * @param  TestResponse<Response>  $response
      * @param  string[]  $versions
      */
     protected function assertRouteVersions(TestResponse $response, array $versions): static
@@ -194,7 +195,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
     /**
      * Assert response has deprecation message
      *
-     * @param  TestResponse<\Illuminate\Http\Response>  $response
+     * @param  TestResponse<Response>  $response
      */
     protected function assertDeprecationMessage(TestResponse $response, string $message): static
     {
@@ -206,7 +207,7 @@ abstract class ApiVersionTestCase extends BaseTestCase
     /**
      * Assert response has replacement version
      *
-     * @param  TestResponse<\Illuminate\Http\Response>  $response
+     * @param  TestResponse<Response>  $response
      */
     protected function assertReplacedBy(TestResponse $response, string $version): static
     {

--- a/src/Traits/HasApiVersionAttributes.php
+++ b/src/Traits/HasApiVersionAttributes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShahGhasiAdil\LaravelApiVersioning\Traits;
 
+use ShahGhasiAdil\LaravelApiVersioning\Services\VersionComparator;
 use ShahGhasiAdil\LaravelApiVersioning\ValueObjects\VersionInfo;
 
 trait HasApiVersionAttributes
@@ -67,7 +68,7 @@ trait HasApiVersionAttributes
             return false;
         }
 
-        return app(\ShahGhasiAdil\LaravelApiVersioning\Services\VersionComparator::class)
+        return app(VersionComparator::class)
             ->isGreaterThan($currentVersion, $version);
     }
 
@@ -81,7 +82,7 @@ trait HasApiVersionAttributes
             return false;
         }
 
-        return app(\ShahGhasiAdil\LaravelApiVersioning\Services\VersionComparator::class)
+        return app(VersionComparator::class)
             ->isGreaterThanOrEqual($currentVersion, $version);
     }
 
@@ -95,7 +96,7 @@ trait HasApiVersionAttributes
             return false;
         }
 
-        return app(\ShahGhasiAdil\LaravelApiVersioning\Services\VersionComparator::class)
+        return app(VersionComparator::class)
             ->isLessThan($currentVersion, $version);
     }
 
@@ -109,7 +110,7 @@ trait HasApiVersionAttributes
             return false;
         }
 
-        return app(\ShahGhasiAdil\LaravelApiVersioning\Services\VersionComparator::class)
+        return app(VersionComparator::class)
             ->isLessThanOrEqual($currentVersion, $version);
     }
 
@@ -123,7 +124,7 @@ trait HasApiVersionAttributes
             return false;
         }
 
-        return app(\ShahGhasiAdil\LaravelApiVersioning\Services\VersionComparator::class)
+        return app(VersionComparator::class)
             ->isBetween($currentVersion, $min, $max);
     }
 }

--- a/src/ValueObjects/VersionInfo.php
+++ b/src/ValueObjects/VersionInfo.php
@@ -4,6 +4,9 @@ namespace ShahGhasiAdil\LaravelApiVersioning\ValueObjects;
 
 class VersionInfo
 {
+    /**
+     * @param  string[]|null  $routeVersions
+     */
     public function __construct(
         public readonly string $version,
         public readonly bool $isNeutral = false,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,13 @@ use ShahGhasiAdil\LaravelApiVersioning\ApiVersioningServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {
+    /**
+     * Declared to satisfy older testbench/Laravel versions that reference this
+     * static property from MakesHttpRequests without always declaring it first,
+     * which causes "Access to undeclared static property" on PHP 8.3+.
+     */
+    public static $latestResponse;
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Unit/ApiVersionsCommandTest.php
+++ b/tests/Unit/ApiVersionsCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Console\OutputStyle;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Routing\Router;
@@ -7,6 +8,8 @@ use ShahGhasiAdil\LaravelApiVersioning\Console\Commands\ApiVersionsCommand;
 use ShahGhasiAdil\LaravelApiVersioning\Services\AttributeVersionResolver;
 use ShahGhasiAdil\LaravelApiVersioning\Services\VersionManager;
 use ShahGhasiAdil\LaravelApiVersioning\ValueObjects\VersionInfo;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 beforeEach(function () {
     $this->router = Mockery::mock(Router::class);
@@ -64,14 +67,14 @@ describe('route filtering and display', function () {
         $this->versionManager->shouldReceive('getSupportedVersions')
             ->andReturn(['1.0', '2.0', '2.1']);
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput;
-        $style = new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
+        $output = new BufferedOutput;
+        $style = new OutputStyle(
+            new ArrayInput([]),
             $output
         );
         $this->command->setOutput($style);
 
-        $input = new \Symfony\Component\Console\Input\ArrayInput([]);
+        $input = new ArrayInput([]);
         $input->bind($this->command->getDefinition());
         $this->command->setInput($input);
 
@@ -127,15 +130,15 @@ describe('route filtering and display', function () {
         $this->versionManager->shouldReceive('getSupportedVersions')
             ->andReturn(['1.0', '2.0']);
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput;
-        $style = new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
+        $output = new BufferedOutput;
+        $style = new OutputStyle(
+            new ArrayInput([]),
             $output
         );
         $this->command->setOutput($style);
 
         // Test with route filter
-        $input = new \Symfony\Component\Console\Input\ArrayInput(['--route' => 'users']);
+        $input = new ArrayInput(['--route' => 'users']);
         $input->bind($this->command->getDefinition());
         $this->command->setInput($input);
 
@@ -169,14 +172,14 @@ describe('route filtering and display', function () {
         $this->versionManager->shouldReceive('getSupportedVersions')
             ->andReturn(['1.0', '2.0']);
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput;
-        $style = new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
+        $output = new BufferedOutput;
+        $style = new OutputStyle(
+            new ArrayInput([]),
             $output
         );
         $this->command->setOutput($style);
 
-        $input = new \Symfony\Component\Console\Input\ArrayInput(['--api-version' => '2.0']);
+        $input = new ArrayInput(['--api-version' => '2.0']);
         $input->bind($this->command->getDefinition());
         $this->command->setInput($input);
 
@@ -221,14 +224,14 @@ describe('route filtering and display', function () {
         $this->versionManager->shouldReceive('getSupportedVersions')
             ->andReturn(['1.0', '2.0']);
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput;
-        $style = new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
+        $output = new BufferedOutput;
+        $style = new OutputStyle(
+            new ArrayInput([]),
             $output
         );
         $this->command->setOutput($style);
 
-        $input = new \Symfony\Component\Console\Input\ArrayInput(['--deprecated' => true]);
+        $input = new ArrayInput(['--deprecated' => true]);
         $input->bind($this->command->getDefinition());
         $this->command->setInput($input);
 
@@ -282,14 +285,14 @@ describe('deprecation information handling', function () {
         $this->versionManager->shouldReceive('getSupportedVersions')
             ->andReturn(['1.0', '2.0']);
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput;
-        $style = new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
+        $output = new BufferedOutput;
+        $style = new OutputStyle(
+            new ArrayInput([]),
             $output
         );
         $this->command->setOutput($style);
 
-        $input = new \Symfony\Component\Console\Input\ArrayInput([]);
+        $input = new ArrayInput([]);
         $input->bind($this->command->getDefinition());
         $this->command->setInput($input);
 
@@ -320,14 +323,14 @@ describe('deprecation information handling', function () {
         $this->versionManager->shouldReceive('getSupportedVersions')
             ->andReturn(['1.0', '2.0']);
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput;
-        $style = new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
+        $output = new BufferedOutput;
+        $style = new OutputStyle(
+            new ArrayInput([]),
             $output
         );
         $this->command->setOutput($style);
 
-        $input = new \Symfony\Component\Console\Input\ArrayInput([]);
+        $input = new ArrayInput([]);
         $input->bind($this->command->getDefinition());
         $this->command->setInput($input);
 
@@ -365,14 +368,14 @@ describe('error handling', function () {
         $this->versionManager->shouldReceive('getSupportedVersions')
             ->andReturn(['1.0', '2.0']);
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput;
-        $style = new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
+        $output = new BufferedOutput;
+        $style = new OutputStyle(
+            new ArrayInput([]),
             $output
         );
         $this->command->setOutput($style);
 
-        $input = new \Symfony\Component\Console\Input\ArrayInput([]);
+        $input = new ArrayInput([]);
         $input->bind($this->command->getDefinition());
         $this->command->setInput($input);
 
@@ -389,14 +392,14 @@ describe('error handling', function () {
         $this->versionManager->shouldReceive('getSupportedVersions')
             ->andReturn(['1.0', '2.0']);
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput;
-        $style = new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
+        $output = new BufferedOutput;
+        $style = new OutputStyle(
+            new ArrayInput([]),
             $output
         );
         $this->command->setOutput($style);
 
-        $input = new \Symfony\Component\Console\Input\ArrayInput([]);
+        $input = new ArrayInput([]);
         $input->bind($this->command->getDefinition());
         $this->command->setInput($input);
 
@@ -423,15 +426,15 @@ describe('error handling', function () {
         $this->versionManager->shouldReceive('getSupportedVersions')
             ->andReturn(['1.0', '2.0']);
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput;
-        $style = new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
+        $output = new BufferedOutput;
+        $style = new OutputStyle(
+            new ArrayInput([]),
             $output
         );
         $this->command->setOutput($style);
 
         // Filter for routes containing 'users' but only 'posts' exists
-        $input = new \Symfony\Component\Console\Input\ArrayInput(['--route' => 'users']);
+        $input = new ArrayInput(['--route' => 'users']);
         $input->bind($this->command->getDefinition());
         $this->command->setInput($input);
 


### PR DESCRIPTION
This pull request updates the package to support newer versions of PHP, Laravel, and related dependencies. The changes ensure compatibility with Laravel 13 and PHP 8.5, and update the testing matrix and dependencies accordingly.

**Dependency and compatibility updates:**

* Increased minimum PHP requirement to `^8.3` and added support for PHP 8.5 in both `composer.json` and the GitHub Actions workflow. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L19-R27) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L24-R29)
* Added support for Laravel 13 (`illuminate/support`, `illuminate/routing`, `illuminate/http`) and updated the testing matrix to include Laravel 13 and the corresponding Testbench version. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L19-R27) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L24-R29)
* Expanded dev dependencies to include Testbench 11 and Pest 4, ensuring tests can run against the latest versions.

**Testing matrix improvements:**

* Removed the `prefer-lowest` stability option from the GitHub Actions matrix, focusing test runs on `prefer-stable` for more realistic scenarios.